### PR TITLE
Potential issue in src/common/platform/win32/base_sysfb.cpp: Unchecked return from initialization function

### DIFF
--- a/src/common/platform/win32/base_sysfb.cpp
+++ b/src/common/platform/win32/base_sysfb.cpp
@@ -78,7 +78,7 @@ EXTERN_CVAR(Int, vid_defheight)
  void SystemBaseFrameBuffer::GetCenteredPos(int in_w, int in_h, int &winx, int &winy, int &winw, int &winh, int &scrwidth, int &scrheight)
 {
 	DEVMODE displaysettings;
-	RECT rect;
+	RECT rect = {};
 	int cx, cy;
 
 	memset(&displaysettings, 0, sizeof(displaysettings));


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**1 instance** of this defect were found in the following locations:

---
**Instance 1**
File : `src/common/platform/win32/base_sysfb.cpp` 
Enclosing Function : `GetCenteredPos@SystemBaseFrameBuffer`
Function : `GetWindowRect@8` 
https://github.com/siva-msft/gzdoom/blob/8480a390a1c7ddd02558daae2dd3257bbc9a2e99/src/common/platform/win32/base_sysfb.cpp#L89
**Issue in**: _rect_

**Code extract**:

```cpp
	EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &displaysettings);
	scrwidth = (int)displaysettings.dmPelsWidth;
	scrheight = (int)displaysettings.dmPelsHeight;
	GetWindowRect(Window, &rect); <------ HERE
	cx = scrwidth / 2;
	cy = scrheight / 2;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
