### PR TITLE
Potential issue in src/common/platform/win32/i_crash.cpp: Unchecked return from initialization function

### DIFF
--- a/src/common/platform/win32/i_crash.cpp
+++ b/src/common/platform/win32/i_crash.cpp
@@ -1013,7 +1013,7 @@ static void StackWalk (HANDLE file, void *dumpaddress, DWORD *topOfStack, DWORD 
 
 			// Check if address is after a call statement. Print what was called if it is.
 			const uint8_t *bytep = (uint8_t *)code;
-			uint8_t peekb;
+			uint8_t peekb = 0;
 
 #define chkbyte(x,m,v) (SafeReadMemory(x, &peekb, 1) && ((peekb & m) == v))
 
@@ -1109,7 +1109,7 @@ static void StackWalk (HANDLE file, void *dumpaddress, DWORD *topOfStack, DWORD 
 
 					if (mod == 1)
 					{
-						signed char miniofs;
+						signed char miniofs = 0;
 						SafeReadMemory (bytep++, &miniofs, 1);
 						offset = miniofs;
 					}
@@ -1881,7 +1881,7 @@ static INT_PTR CALLBACK CrashDlgProc (HWND hDlg, UINT message, WPARAM wParam, LP
 	static WCHAR details[] = L"Details";
 	HWND edit;
 	TCITEM tcitem;
-	RECT tabrect, tcrect;
+	RECT tabrect, tcrect = {};
 	LPNMHDR nmhdr;
 
 	switch (message)


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**4 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `src/common/platform/win32/i_crash.cpp` 
Enclosing Function : `StackWalk`
Function : `SafeReadMemory` 
https://github.com/siva-msft/gzdoom/blob/8480a390a1c7ddd02558daae2dd3257bbc9a2e99/src/common/platform/win32/i_crash.cpp#L1066
**Issue in**: _peekb_

**Code extract**:

```cpp

					Writef (file, "\r\n %08x", bytep - i);
					bytep -= i - 1;
					SafeReadMemory (bytep, &peekb, 1); <------ HERE
					mod = peekb >> 6;
					rm = peekb & 7;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `src/common/platform/win32/i_crash.cpp` 
Enclosing Function : `StackWalk`
Function : `SafeReadMemory` 
https://github.com/siva-msft/gzdoom/blob/8480a390a1c7ddd02558daae2dd3257bbc9a2e99/src/common/platform/win32/i_crash.cpp#L1079
**Issue in**: _peekb_

**Code extract**:

```cpp
					{
						int index, base;

						SafeReadMemory (bytep, &peekb, 1); <------ HERE
						scale = 1 << (peekb >> 6);
						index = (peekb >> 3) & 7;
```

**How can I fix it?** 
Correct reference usage found in `src/common/platform/win32/i_crash.cpp` at line `1309`.
https://github.com/siva-msft/gzdoom/blob/8480a390a1c7ddd02558daae2dd3257bbc9a2e99/src/common/platform/win32/i_crash.cpp#L1309
**Code extract**:

```cpp
		{
			line_p += mysnprintf (line_p, countof(line) - (line_p - line), "\r\n%p:", address);
		}
		if (SafeReadMemory (address, &peek, 1)) <------ HERE
		{
			line_p += mysnprintf (line_p, countof(line) - (line_p - line), " %02x", *address);
```


---
**Instance 3**
File : `src/common/platform/win32/i_crash.cpp` 
Enclosing Function : `StackWalk`
Function : `SafeReadMemory` 
https://github.com/siva-msft/gzdoom/blob/8480a390a1c7ddd02558daae2dd3257bbc9a2e99/src/common/platform/win32/i_crash.cpp#L1113
**Issue in**: _miniofs_

**Code extract**:

```cpp
					if (mod == 1)
					{
						signed char miniofs;
						SafeReadMemory (bytep++, &miniofs, 1); <------ HERE
						offset = miniofs;
					}
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 4**
File : `src/common/platform/win32/i_crash.cpp` 
Enclosing Function : `CrashDlgProc`
Function : `GetWindowRect@8` 
https://github.com/siva-msft/gzdoom/blob/8480a390a1c7ddd02558daae2dd3257bbc9a2e99/src/common/platform/win32/i_crash.cpp#L1894
**Issue in**: _tcrect_

**Code extract**:

```cpp
		tcitem.mask = TCIF_TEXT | TCIF_PARAM;
		edit = GetDlgItem (hDlg, IDC_CRASHTAB);

		GetWindowRect (edit, &tcrect); <------ HERE
		ScreenToClient (hDlg, (LPPOINT)&tcrect.left);
		ScreenToClient (hDlg, (LPPOINT)&tcrect.right);
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
