### PR TITLE
Potential issue in src/common/platform/win32/i_system.cpp: Unchecked return from initialization function

### DIFF
--- a/src/common/platform/win32/i_system.cpp
+++ b/src/common/platform/win32/i_system.cpp
@@ -286,7 +286,7 @@ static void DoPrintStr(const char *cpt, HWND edit, HANDLE StdOut)
 
 	wchar_t wbuf[256];
 	int bpos = 0;
-	CHARRANGE selection;
+	CHARRANGE selection = {};
 	CHARRANGE endselection;
 	LONG lines_before = 0, lines_after;
 	CHARFORMAT format;
@@ -322,7 +322,7 @@ static void DoPrintStr(const char *cpt, HWND edit, HANDLE StdOut)
 		if (StdOut != nullptr)
 		{
 			// Convert back to UTF-8.
-			DWORD bytes_written;
+			DWORD bytes_written = 0;
 			if (!FancyStdOut)
 			{
 				FString conout(wbuf);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**2 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `src/common/platform/win32/i_system.cpp` 
Enclosing Function : `DoPrintStr`
Function : `SendMessageW@16` 
https://github.com/siva-msft/gzdoom/blob/8480a390a1c7ddd02558daae2dd3257bbc9a2e99/src/common/platform/win32/i_system.cpp#L297
**Issue in**: _selection_

**Code extract**:

```cpp
	if (edit != NULL)
	{
		// Store the current selection and set it to the end so we can append text.
		SendMessage(edit, EM_EXGETSEL, 0, (LPARAM)&selection); <------ HERE
		endselection.cpMax = endselection.cpMin = GetWindowTextLength(edit);
		SendMessage(edit, EM_EXSETSEL, 0, (LPARAM)&endselection);
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `src/common/platform/win32/i_system.cpp` 
Enclosing Function : `R<lambda_a7f24bb8ce88254f01ae524d0bc1a1c0>`
Function : `WriteFile@20` 
https://github.com/siva-msft/gzdoom/blob/8480a390a1c7ddd02558daae2dd3257bbc9a2e99/src/common/platform/win32/i_system.cpp#L329
**Issue in**: _bytes_written_

**Code extract**:

```cpp
			if (!FancyStdOut)
			{
				FString conout(wbuf);
				WriteFile(StdOut, conout.GetChars(), (DWORD)conout.Len(), &bytes_written, NULL); <------ HERE
			}
			else
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
