### PR TITLE
Potential issue in src/common/platform/win32/st_start.cpp: Unchecked return from initialization function

### DIFF
--- a/src/common/platform/win32/st_start.cpp
+++ b/src/common/platform/win32/st_start.cpp
@@ -226,7 +226,7 @@ void FBasicStartupScreen::NetInit(const char *message, int numplayers)
 			DestroyWindow (ProgressBar);
 			ProgressBar = NULL;
 		}
-		RECT winrect;
+		RECT winrect = {};
 		GetWindowRect (Window, &winrect);
 		SetWindowPos (Window, NULL, 0, 0,
 			winrect.right - winrect.left, winrect.bottom - winrect.top + LayoutNetStartPane (NetStartPane, 0),
@@ -646,7 +646,7 @@ void ST_Util_SizeWindowForBitmap (int scale)
 {
 	DEVMODE displaysettings;
 	int w, h, cx, cy, x, y;
-	RECT rect;
+	RECT rect = {};
 
 	if (GameTitleWindow != NULL)
 	{
@@ -702,7 +702,7 @@ void ST_Util_SizeWindowForBitmap (int scale)
 
 void ST_Util_InvalidateRect (HWND hwnd, BitmapInfo *bitmap_info, int left, int top, int right, int bottom)
 {
-	RECT rect;
+	RECT rect = {};
 
 	GetClientRect (hwnd, &rect);
 	rect.left = left * rect.right / bitmap_info->bmiHeader.biWidth - 1;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**3 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `src/common/platform/win32/st_start.cpp` 
Enclosing Function : `NetInit@FBasicStartupScreen`
Function : `GetWindowRect@8` 
https://github.com/siva-msft/gzdoom/blob/8480a390a1c7ddd02558daae2dd3257bbc9a2e99/src/common/platform/win32/st_start.cpp#L230
**Issue in**: _winrect_

**Code extract**:

```cpp
			ProgressBar = NULL;
		}
		RECT winrect;
		GetWindowRect (Window, &winrect); <------ HERE
		SetWindowPos (Window, NULL, 0, 0,
			winrect.right - winrect.left, winrect.bottom - winrect.top + LayoutNetStartPane (NetStartPane, 0),
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `src/common/platform/win32/st_start.cpp` 
Enclosing Function : `ST_Util_SizeWindowForBitmap`
Function : `GetClientRect@8` 
https://github.com/siva-msft/gzdoom/blob/8480a390a1c7ddd02558daae2dd3257bbc9a2e99/src/common/platform/win32/st_start.cpp#L653
**Issue in**: _rect_

**Code extract**:

```cpp

	if (GameTitleWindow != NULL)
	{
		GetClientRect (GameTitleWindow, &rect); <------ HERE
	}
	else
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 3**
File : `src/common/platform/win32/st_start.cpp` 
Enclosing Function : `ST_Util_InvalidateRect`
Function : `GetClientRect@8` 
https://github.com/siva-msft/gzdoom/blob/8480a390a1c7ddd02558daae2dd3257bbc9a2e99/src/common/platform/win32/st_start.cpp#L707
**Issue in**: _rect_

**Code extract**:

```cpp
{
	RECT rect;

	GetClientRect (hwnd, &rect); <------ HERE
	rect.left = left * rect.right / bitmap_info->bmiHeader.biWidth - 1;
	rect.top = top * rect.bottom / bitmap_info->bmiHeader.biHeight - 1;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
